### PR TITLE
Save `submission_time` column in addition to `snapshot_time`

### DIFF
--- a/vignettes/dashboard.Rmd
+++ b/vignettes/dashboard.Rmd
@@ -42,7 +42,7 @@ cran_incoming <- cran_raw %>%
   )
 
 cran_incoming %>% 
-  select(package, version, snapshot_time, folder, subfolder) %>% 
+  select(package, version, submission_time, folder, subfolder) %>% 
   arrange(package, version) %>% 
   write.csv(
     paste0("cran-incoming-", format(Sys.time(), "%Y%m%dT%H%M"), ".csv"),

--- a/vignettes/dashboard.Rmd
+++ b/vignettes/dashboard.Rmd
@@ -42,7 +42,7 @@ cran_incoming <- cran_raw %>%
   )
 
 cran_incoming %>% 
-  select(package, version, submission_time, folder, subfolder) %>% 
+  select(package, version, snapshot_time, folder, subfolder, submission_time) %>% 
   arrange(package, version) %>% 
   write.csv(
     paste0("cran-incoming-", format(Sys.time(), "%Y%m%dT%H%M"), ".csv"),


### PR DESCRIPTION
`snapshot_time` is largely redundant with information contained in the file name anyways

Fix #36
Fix #49

I see no real reason to save `snapshot_time` so I went with the option of replacing it instead of keeping both columns. @llrs, as a downstream user of this data, what do you think?