### PR TITLE
Put the same timezone for the columns `snapshot_time` and `submission_time`

### DIFF
--- a/R/take-snapshot.R
+++ b/R/take-snapshot.R
@@ -48,7 +48,8 @@ take_snapshot <- function(){
                                                    tz="Europe/Vienna"),
       submission_time = dplyr::if_else(as.numeric(snapshot_time - submission_time, units = "days") < 0,
                                lubridate::parse_date_time(paste(as.numeric(as.character(year)) - 1, V6, V7, time),
-                                                          "%Y %b %d %R"),
+                                                          "%Y %b %d %R",
+                                                          tz="Europe/Vienna"),
                                submission_time),
       howlongago = round(as.numeric(snapshot_time - submission_time, units = "days"), digits = 1)
     ) %>%


### PR DESCRIPTION
Thanks for this package, it is very useful!

When using it, I had the impression that the indicated submission time was off by 2 hours, until I realized that the `snapshot_time` and the `submission_time` columns are in two different timezones, as can be seen in the following reprex:

``` r
dat = cransays::take_snapshot()
dat$snapshot_time[1]
#> [1] "2022-04-25 17:40:36 CEST"
dat$submission_time[1]
#> [1] "2022-04-22 08:31:00 UTC"
```

This is because the `submission_time` is merged with the function `lubridate::parse_date_time`, which by default uses the UTC timezone and is therefore converted in the UTC timezone (even if it was in the CEST timezone before).