### PR TITLE
Set website push actor to GitHub Actions bot

### DIFF
--- a/.github/workflows/render-dashboard.yml
+++ b/.github/workflows/render-dashboard.yml
@@ -38,6 +38,8 @@ jobs:
           clean: false
           branch: gh-pages
           folder: docs
+          git-config-name: 'GitHub Actions'
+          git-config-email: 'actions@github.com'
 
       - uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
This is in line with what is done on the `history` branch and is more informative & more logical than using my username.

Relevant documentation for this change is here: https://github.com/JamesIves/github-pages-deploy-action#optional-choices