### PR TITLE
Fix link on webpage

### DIFF
--- a/vignettes/dashboard.Rmd
+++ b/vignettes/dashboard.Rmd
@@ -18,7 +18,7 @@ knitr::opts_chunk$set(
 )
 ```
 
-The data in this table stems from our querying ftp://cran.r-project.org/incoming/.
+The data in this table stems from our querying https://cran.r-project.org/incoming/.
 We update it every hour. [See below](#cran-review-workflow) for a description of each 
 folder meaning.
 


### PR DESCRIPTION
The link on https://r-hub.github.io/cransays/articles/dashboard.html cannot be opened in most browsers because they do not support ftp anymore. However CRAN has enabled HTTP access to their incoming dir now.