### PR TITLE
Use build_site() directly

### DIFF
--- a/.github/workflows/render-dashboard.yml
+++ b/.github/workflows/render-dashboard.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: r-lib/actions/setup-renv@v2
 
       - name: Build site
-        run: pkgdown::build_site_github_pages(new_process = FALSE, install = TRUE)
+        run: pkgdown::build_site(new_process = FALSE, install = TRUE)
         shell: Rscript {0}
 
       - name: Upload artifact


### PR DESCRIPTION
since we want clean = FALSE to leverage pkgdown built-in caching