### PR TITLE
Make `take_snapshot()` faster

### DIFF
--- a/R/take-snapshot.R
+++ b/R/take-snapshot.R
@@ -22,7 +22,10 @@ take_snapshot <- function(){
 
   # one level more for humans
   # since they use subfolders
-  cran_human <- c("BA", "DS", "KH", "KL", "SH", "UL", "VW")
+  cran_human <- setdiff(
+    folders,
+    c("archive", "inspect", "newbies", "pending", "pretest", "publish", "recheck", "waiting")
+  )
   human_folders <- cran_incoming %>%
     dplyr::filter(
       subfolder %in% cran_human,

--- a/R/take-snapshot.R
+++ b/R/take-snapshot.R
@@ -24,7 +24,10 @@ take_snapshot <- function(){
   # since they use subfolders
   cran_human <- c("BA", "DS", "KH", "KL", "SH", "UL", "VW")
   human_folders <- cran_incoming %>%
-    dplyr::filter(subfolder %in% cran_human) %>%
+    dplyr::filter(
+      subfolder %in% cran_human,
+      startsWith(V1, "d") # only directories
+    ) %>%
     with(paste0(base_ftp_url(), subfolder, "/", V9, "/"))
 
   cran_incoming <- human_folders %>%

--- a/R/take-snapshot.R
+++ b/R/take-snapshot.R
@@ -22,7 +22,7 @@ take_snapshot <- function(){
 
   # one level more for humans
   # since they use subfolders
-  cran_human <- c("DS", "UL", "SH", "KH")
+  cran_human <- c("BA", "DS", "KH", "KL", "SH", "UL", "VW")
   human_folders <- cran_incoming %>%
     dplyr::filter(subfolder %in% cran_human) %>%
     with(paste0(base_ftp_url(), subfolder, "/", V9, "/"))

--- a/R/take-snapshot.R
+++ b/R/take-snapshot.R
@@ -38,7 +38,7 @@ take_snapshot <- function(){
 
   # Tidy results ------------------------------------------------------
   cran_incoming <- cran_incoming %>%
-    dplyr::filter(grepl(".*\\.tar\\.gz", V9)) %>% # Remove non-package files
+    dplyr::filter(endsWith(V9, ".tar.gz")) %>% # Remove non-package files
     dplyr::mutate(
       year = ifelse(grepl(":", V8, fixed = TRUE), format(snapshot_time, "%Y"), V8),
       time = ifelse(grepl(":", V8, fixed = TRUE), V8, "00:00"),


### PR DESCRIPTION
In preparation to potentially address #76.

This cuts computation time in ~half.

## this branch 

```
# user  system elapsed 
# 0.370   0.554  29.671 
```

## main

```
# user  system elapsed 
# 0.611   0.489  45.939 
```

This matches with the theory since we cut (at the time of writing) the number of folders to visit from 66 to 30.

However, it seems that

https://github.com/r-hub/cransays/blob/b0cc818c69ebf389cc2f1122e3141ac5da19d93d/R/take-snapshot.R#L23-L24

is no longer true so we could potentially remove it all and hit the ftp server only once instead of 31 :thinking:. Since there are no official documentation of the folder structure though, it's entirely possible they go back to using folders at some point.