### PR TITLE
Use git pull --rebase before attempting git push

### DIFF
--- a/.github/workflows/render-dashboard.yml
+++ b/.github/workflows/render-dashboard.yml
@@ -83,6 +83,7 @@ jobs:
           git config user.name "GitHub Actions"
           git add cran-incoming-*.csv
           git commit -m 'new data'
+          git pull --rebase
           git push
           echo "pushed to github"
 


### PR DESCRIPTION
Should address https://github.com/r-hub/cransays/issues/53#issuecomment-2078927746.

Discussed in https://epiforecasts.io/posts/2022-04-11-robust-actions/#git-repository-out-of-sync.

It took me a while to implement this as I was unsure about whether it could lead to out-of-sync snapshots in history. After staring at the code & GHA logs for a while today, I don't think it's an issue as the time in the csv file name is saved right after we do the CRAN snapshot.
If workflows take a while to get started, to install packages, etc., and snapshots are uploaded out of order, it shouldn't matter because the recorded time is still correct.
