### PR TITLE
Add seconds to filename for historical archives

### DIFF
--- a/vignettes/dashboard.Rmd
+++ b/vignettes/dashboard.Rmd
@@ -47,7 +47,7 @@ cran_incoming %>%
   select(package, version, snapshot_time, folder, subfolder, submission_time) %>% 
   arrange(package, version) %>% 
   write.csv(
-    paste0("cran-incoming-v5-", format(Sys.time(), "%Y%m%dT%H%M"), ".csv"),
+    paste0("cran-incoming-v5-", format(Sys.time(), "%Y%m%dT%H%M%S"), ".csv"),
     row.names = FALSE,
     quote = FALSE
   )


### PR DESCRIPTION
To avoid conflicts when two workflows happen to snapshot at the same minute.